### PR TITLE
Update DMG boot rom hashes

### DIFF
--- a/chapter/peripherals/boot-rom.tex
+++ b/chapter/peripherals/boot-rom.tex
@@ -72,7 +72,7 @@ the system.
     \hline
     Type & CRC32 & MD5 & SHA1 \\
     \hline
-    DMG & \texttt{59c8598e} & \texttt{a8f84a0ac44da5d3f0ee19f9cea80a8c} & \texttt{8bd501e31921e9601788316dbd3ce9833a97bcbc} \\
+    DMG & \texttt{59c8598e} & \texttt{32fbbd84168d3482956eb3c5051637f5} & \texttt{4ed31ec6b0b175bb109c0eb5fd3d193da823339f} \\
     \hline
     MGB & \texttt{e6920754} & \texttt{71a378e71ff30b2d8a1f02bf5c7896aa} & \texttt{4e68f9da03c310e84c523654b9026e51f26ce7f0} \\
     \hline


### PR DESCRIPTION
The MD5 and SHA1 hashes for the DMG boot rom are currently listed as being the same as DMG0.