### PR TITLE
PPU status register renamed from LCDL to STAT

### DIFF
--- a/chapter/peripherals/ppu.tex
+++ b/chapter/peripherals/ppu.tex
@@ -23,7 +23,7 @@
 \end{register}
 
 \begin{register}[H]
-  \caption{\hex{FF41} - LCDC - PPU status register}
+  \caption{\hex{FF41} - STAT - PPU status register}
   {
     \ttfamily
     \begin{tabularx}{\linewidth}{|X|X|X|X|X|X|X|X|}


### PR DESCRIPTION
Hi,
I guess it was a typo. I propose STAT as in the PanDoc