### PR TITLE
fixed typo on XOR (HL) indirect opcode

### DIFF
--- a/chapter/cpu/instruction-set.tex
+++ b/chapter/cpu/instruction-set.tex
@@ -1683,7 +1683,7 @@ Performs a bitwise XOR operation between the 8-bit A register and data from the 
 
 \begin{description}[leftmargin=9em, style=nextline]
   \item[Opcode]
-    \bin{10101110}/\hex{BE}
+    \bin{10101110}/\hex{AE}
   \item[Length]
     1 byte
   \item[Duration]


### PR DESCRIPTION
XOR(HL) has the following text: `Opcode 0b10101110/0xBE` which is the correct binary but incorrect hex. should instead read `Opcode 0b10101110/0xAE`